### PR TITLE
dualsim: various fixes

### DIFF
--- a/product/qcom-radio.mk
+++ b/product/qcom-radio.mk
@@ -2,9 +2,7 @@
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.radio.custom_ecc=1 \
     persist.radio.ecc_hard_1=998 \
-    persist.radio.ecc_hard_count=1 \
-    rild.libpath=/system/vendor/lib64/libril-qc-qmi-1.so \
-    rild.libargs=-d /dev/smd0
+    persist.radio.ecc_hard_count=1
 
 # RIL
 ifeq ($(QCPATH),)

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -456,10 +456,12 @@ on property:hw.fm.init=1
 service qmuxd /system/bin/qmuxd
     class main
     user root
-    group radio audio bluetooth gps nfc qcom_diag
+    group radio audio bluetooth gps nfc qcom_diag wakelock
 
 service netmgrd /system/bin/netmgrd
     class core
+    user root
+    group radio
 
 on property:ro.use_data_netmgrd=false
     # netmgr not supported on specific target
@@ -522,14 +524,22 @@ on property:ro.data.large_tcp_window_size=true
     # Adjust socket buffer to enlarge TCP receive window for high bandwidth (e.g. DO-RevB)
     write /proc/sys/net/ipv4/tcp_adv_win_scale  2
 
-service ril-daemon1 /system/bin/rild -c 2
+on property:init.svc.ril-daemon=running && property:persist.radio.multisim.config=dsds
+    wait /dev/socket/qmux_radio/rild_oem0
+    start ril-daemon2
+
+#on property:persist.radio.multisim.config=dsds
+#     enable ril-daemon2
+
+service ril-daemon2 /system/bin/rild -c 2
     class main
     socket rild2 stream 660 root radio
     socket rild-debug2 stream 660 radio system
+    socket sap_uim_socket2 stream 660 bluetooth bluetooth
     socket cutback stream 660 media radio
     user root
     disabled
-    group radio cache inet misc audio sdcard_r sdcard_rw qcom_diag log
+    group radio cache inet misc audio log readproc wakelock qcom_diag
 
 service charger /charger
     class charger

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,0 +1,2 @@
+# For /dev/socket/cutback (specific to dualsim second RIL daemon)
+allow init socket_device:sock_file { create setattr unlink } ;

--- a/sepolicy/radio.te
+++ b/sepolicy/radio.te
@@ -1,0 +1,1 @@
+allow radio system_app_data_file:dir getattr;

--- a/system.prop
+++ b/system.prop
@@ -74,3 +74,8 @@ ro.sf.lcd_density=480
 # Wifi
 ro.disableWifiApFirmwareReload=true
 wifi.interface=wlan0
+
+# Moved to work-around smd0 being on a newline in build.prop when set from qcom-radio.mk
+rild.libpath=/system/vendor/lib64/libril-qc-qmi-1.so
+rild.libargs=-d /dev/smd0
+


### PR DESCRIPTION
- rild.libargs setting from qcom-radio.mk gets split on a newline in build.prop,
  so set it form system.prop
- second ril-daemon was not started, trigger it when the first starts and dsds is set
- set ril-daemon2 groups similar to ril-daemon, also add sap_uim_socket2
- sepolicy changes for cutback socket creation and telephony access to settings
- add missing user/group for netmgrd (not specific to dualsim case)

Change-Id: I0524f99420d0870bd51b23fec7c2984249282cc0